### PR TITLE
Uses the base library instead of stdlib

### DIFF
--- a/src/Parsec.mo
+++ b/src/Parsec.mo
@@ -15,12 +15,12 @@
 // checking (not synthesizing) a function against an expected function type.
 // Choose your poison.
 
-import Array "mo:stdlib/Array";
-import Char "mo:stdlib/Char";
-import Debug "mo:stdlib/Debug";
-import Iter "mo:stdlib/Iter";
-import List "mo:stdlib/List";
-import Text "mo:stdlib/Text";
+import Array "mo:base/Array";
+import Char "mo:base/Char";
+import Debug "mo:base/Debug";
+import Iter "mo:base/Iter";
+import List "mo:base/List";
+import Text "mo:base/Text";
 import Prim "mo:prim"; // TODO: remove me once Char.toText available
 
 module {

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+.vessel/
+*.wasm

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,17 +1,11 @@
-# Makefile for motoko  demos
-
-# This works with bash
-
-MOC?=~/motoko/src/moc
-STDLIB?=~/motoko/stdlib/src
+MOC ?= ./moc
+PKGS=$(shell vessel sources)
 # we need to specify the output if there is more than one .mo file
 OUT=lambda-calculus.wasm
 
-SAMPLES:= test
-
 all:
-	$(MOC) --package stdlib $(STDLIB) -wasi-system-api lambda-calculus.mo
-	wasmtime lambda-calculus.wasm
+	$(MOC) $(PKGS) -wasi-system-api lambda-calculus.mo
+	wasmtime $(OUT)
 
 clean:
 	rm -f $(OUT)

--- a/test/lambda-calculus.mo
+++ b/test/lambda-calculus.mo
@@ -1,6 +1,6 @@
-import Debug "mo:stdlib/Debug";
-import Iter "mo:stdlib/Iter";
-import List "mo:stdlib/List";
+import Debug "mo:base/Debug";
+import Iter "mo:base/Iter";
+import List "mo:base/List";
 
 import P "../src/Parsec";
 

--- a/test/moc
+++ b/test/moc
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+cache_path="$(dfx cache show)"
+
+if ! test -d $cache_path
+then
+  echo "Could not find \"$cache_path\", as reported by \"dfx cache show\". Is dfx installed?"
+  exit 1
+fi
+
+if ! test -e $cache_path/moc
+then
+  echo "Could not find \"$cache_path/moc\". Maybe your dfx is too old or new?"
+  exit 1
+fi
+
+if ! test -e $cache_path/mo-rts.wasm
+then
+  echo "Could not find \"$cache_path/mo-rts.wasm\". Maybe your dfx is too old or new?"
+  exit 1
+fi
+
+export MOC_RTS="$cache_path/mo-rts.wasm"
+exec "$cache_path/moc" "$@"

--- a/test/package-set.json
+++ b/test/package-set.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "base",
+    "repo": "git@github.com:dfinity-lab/motoko-base.git",
+    "version": "a44f1b41bf29ba7a7f179fb2c04406c1030fb583",
+    "dependencies": []
+  }
+]

--- a/test/vessel.json
+++ b/test/vessel.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": ["base"]
+}


### PR DESCRIPTION
Once `motoko-base` has a proper tagged version and is available as a public repo we can update the `package-set.json` file. Until then this should work and remove any dependency on the compiler repository on the users machine.